### PR TITLE
Add dynamic mute command syntax for mute length

### DIFF
--- a/src/commands/public/mute.js
+++ b/src/commands/public/mute.js
@@ -11,8 +11,9 @@ module.exports = class extends Command {
   }
 
   async execute(message) {
-    const match = /(?:mute)\s+(?:(?:<@!?)?(\d{17,20})>?)(?:\s+(\d+))(?:\s+([\w\W]+))/.exec(message.content);
-    if (!match) return message.reply("Invalid Syntax: mute <user-id/mention> <time-in-minutes> <reason>");
+    // match[] - msg content, ID, length:days?, length: hours?, length:minutes?, length:seconds?, reason 
+    const match = /(?:mute)\s+(?:(?:<@!?)?(\d{17,20})>?)(?:\s+(?:(\d+)\s*d(?:ays)?)?\s*(?:(\d+)\s*h(?:ours|rs|r)?)?\s*(?:(\d+)\s*m(?:inutes|in)?)?\s*(?:(\d+)\s*s(?:econds|ec)?)?)(?:\s+([\w\W]+))/.exec(message.content);
+    if (!match) return message.reply("Invalid Syntax: mute <user-id/mention> <#d#h#m#s> <reason>");
 
     const gSettings = this.client.db.settings.get(message.guild.id);
 
@@ -32,7 +33,14 @@ module.exports = class extends Command {
     detCat = message.guild.channels.get(detCat);
 
     await muteMember.roles.add(muteRole);
-    const endTime = Date.now() + (Number(match[2]) * 60 * 1000);
+
+    const muteLengthMS =
+      ((60 * 60 * 24 * (match[2] ? Number(match[2]) : 0)) +
+        (60 * 60 * (match[3] ? Number(match[3]) : 0)) +
+        (60 * (match[4] ? Number(match[4]) : 0)) +
+        (match[5] ? Number(match[5]) : 0)) * 1000;
+    const muteLengthStr = `${match[2] ? `${match[2]}d` : ""}${match[3] ? `${match[3]}h` : ""}${match[4] ? `${match[4]}m` : ""}${match[5] ? `${match[5]}s` : ""}`;
+    const endTime = Date.now() + muteLengthMS;
 
     const muteChan = await message.guild.channels.create(
       `mute-${muteUser.username.replace(/\s/, '-')}`,
@@ -47,18 +55,18 @@ module.exports = class extends Command {
       VIEW_CHANNEL: true
     });
 
-    await muteUser.send({ embed: this.client.constants.embedTemplates.dm(message, `Muted (${match[2]} minutes)`, match[3]) })
+    await muteUser.send({ embed: this.client.constants.embedTemplates.dm(message, `Muted (${muteLengthStr})`, match[6]) })
       .catch(() => message.reply('Unable to DM user.'));
 
     let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
-      logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, muteUser, `Mute (${match[2]} minutes)`, match[3]) });
+      logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, muteUser, `Mute (${muteLengthStr})`, match[6]) });
     }
 
     this.client.db.tempModActions.set(`${message.guild.id}-${muteUser.id}`, { action: "mute", endTime });
     this.client.db.detention.set(`${message.guild.id}-${muteUser.id}`, muteChan.id);
-    this.client.handlers.modNotes.addAction(message, muteUser, message.author, `Mute (${match[2]} minutes)`, match[3]);
+    this.client.handlers.modNotes.addAction(message, muteUser, message.author, `Mute (${muteLengthStr})`, match[6]);
 
     return message.reply(`${muteUser.tag} has been muted.`);
   }


### PR DESCRIPTION
This PR changes the regex used within the mute command to allow for more flexible (and therefore easier to use) syntax. Previously, all mute commands required the moderator to calculate the time in minutes, but now moderators can use #d#h#m#s (mix and match) to specify length.

Example commands:
- mute @Test#9999 1h2m some reason
- mute @Test#9999 1d3m5s some other reason