### PR TITLE
feat: 🎸 Added emoji stats command front-end

### DIFF
--- a/src/commands/public/emojistats.js
+++ b/src/commands/public/emojistats.js
@@ -12,11 +12,11 @@ module.exports = class extends Command {
   }
 
   async execute(message) {
-    const sorted = new Map([...this.client.db.emojiStats.entries()].sort((usageCount, emojiID) => emojiID[1] - usageCount[1]))
+    const sorted = new Map([...this.client.db.emojiStats.entries()].sort((a, b) => b[1] - a[1]));
     let embedDescription = "";
     sorted.forEach((usageCount, emojiID) => {
-      let emojiName = message.guild.emojis.find(emoji => emoji.id === emojiID).name
-      embedDescription += `<:${emojiName}:${emojiID}> \`${emojiName}: ${usageCount.toLocaleString()} usages\` \n`
+      let emojiName = message.guild.emojis.find(emoji => emoji.id === emojiID).name;
+      embedDescription += `<:${emojiName}:${emojiID}> \`${emojiName}: ${usageCount.toLocaleString()} usages\` \n`;
     });
     const embed = new MessageEmbed().setTitle("Emoji Stats").setDescription(`${embedDescription}`).setColor(0x00FFFF);
     await message.channel.send({ embed: embed });

--- a/src/commands/public/emojistats.js
+++ b/src/commands/public/emojistats.js
@@ -19,6 +19,6 @@ module.exports = class extends Command {
       embedDescription += `<:${emojiName}:${emojiID}> \`${emojiName}: ${usageCount.toLocaleString()} usages\` \n`;
     });
     const embed = new MessageEmbed().setTitle("Emoji Stats").setDescription(`${embedDescription}`).setColor(0x00FFFF);
-    await message.channel.send({ embed: embed });
+    await message.channel.send({embed});
   }
 };

--- a/src/commands/public/emojistats.js
+++ b/src/commands/public/emojistats.js
@@ -1,0 +1,24 @@
+const Command = require("../../structures/command.js");
+const { MessageEmbed } = require("discord.js");
+
+module.exports = class extends Command {
+  constructor(client) {
+    super(client, {
+      name: "emojistats",
+      aliases: [],
+      ltu: client.constants.perms.staff,
+      selfhost: true
+    });
+  }
+
+  async execute(message) {
+    const sorted = new Map([...this.client.db.emojiStats.entries()].sort((usageCount, emojiID) => emojiID[1] - usageCount[1]))
+    let embedDescription = "";
+    sorted.forEach((usageCount, emojiID) => {
+      let emojiName = message.guild.emojis.find(emoji => emoji.id === emojiID).name
+      embedDescription += `<:${emojiName}:${emojiID}> \`${emojiName}: ${usageCount.toLocaleString()} usages\` \n`
+    });
+    const embed = new MessageEmbed().setTitle("Emoji Stats").setDescription(`${embedDescription}`).setColor(0x00FFFF);
+    await message.channel.send({ embed: embed });
+  }
+};

--- a/src/commands/public/emojistats.js
+++ b/src/commands/public/emojistats.js
@@ -15,7 +15,7 @@ module.exports = class extends Command {
     const sorted = new Map([...this.client.db.emojiStats.entries()].sort((a, b) => b[1] - a[1]));
     let embedDescription = "";
     sorted.forEach((usageCount, emojiID) => {
-      let emojiName = message.guild.emojis.find(emoji => emoji.id === emojiID).name;
+      let emojiName = message.guild.emojis.get(emojiID).name;
       embedDescription += `<:${emojiName}:${emojiID}> \`${emojiName}: ${usageCount.toLocaleString()} usages\` \n`;
     });
     const embed = new MessageEmbed().setTitle("Emoji Stats").setDescription(`${embedDescription}`).setColor(0x00FFFF);


### PR DESCRIPTION
Implemented front-end so that PR #8 is easily accessible via Discord chat. 

Command is **emojistats, substituting the ** prefix for the prefix setsudo is configured to use. Command returns an embed with all of the emojis that have been used in the Discord Guild, sorted from highest usage to lowest usage.

