### PR TITLE
fix: 🐛 Changed emojistats frontend to asciidoc embed

### DIFF
--- a/src/commands/public/emojistats.js
+++ b/src/commands/public/emojistats.js
@@ -13,7 +13,7 @@ module.exports = class extends Command {
 
   async execute(message) {
     const sorted = new Map([...this.client.db.emojiStats.entries()].sort((a, b) => b[1] - a[1]));
-    let embed = `\`\`\`asciidoc\n= Emoji Stats for r/smashbros\n`;
+    let embed = `\`\`\`asciidoc\n= Emoji stats for ${message.guild.name}\n`;
     sorted.forEach((usageCount, emojiID) => {
       const emoji = message.guild.emojis.get(emojiID);
       const emojiList = message.guild.emojis.map(e => e.name);

--- a/src/commands/public/emojistats.js
+++ b/src/commands/public/emojistats.js
@@ -13,11 +13,13 @@ module.exports = class extends Command {
 
   async execute(message) {
     const sorted = new Map([...this.client.db.emojiStats.entries()].sort((a, b) => b[1] - a[1]));
-    let emojiStats = `__**Emoji Stats for ${message.guild.name}**__\n`;
+    let embed = `\`\`\`asciidoc\n= Emoji Stats for r/smashbros\n`;
     sorted.forEach((usageCount, emojiID) => {
       const emoji = message.guild.emojis.get(emojiID);
-      if (emoji) emojiStats += `<:${emoji.name}:${emojiID}> \`${emoji.name}: ${usageCount.toLocaleString()} usages\` \n`;
+      const emojiList = message.guild.emojis.map(e => e.name);
+      if (emoji) embed += `${emoji.name}${" ".repeat(Math.max(...(emojiList.map(el => el.length))) - emoji.name.length + 1)}:: ${usageCount.toLocaleString()} usages\n`;
     });
-    message.channel.send(emojiStats, { split: true });
+    embed += `\`\`\``;
+    message.channel.send(embed, { split: true });
   }
 };


### PR DESCRIPTION
Discord didn't play nicely with printing hundreds of emojis in one message so changed it over to a simple and cleanly formatted asciidoc embed. Quick example of an output:

```
= Emoji Stats for r/smashbros
GEXAUSSIE      :: 100,001 usages
yes            :: 10,001 usages
PiranhaPlant   :: 1,001 usages
pacShrug       :: 3 usages
bot            :: 2 usages
takis          :: 1 usages
spidercina     :: 1 usages
```