### PR TITLE
Allow channel selection within randomreact command (#18)

### DIFF
--- a/src/commands/public/randomreact.js
+++ b/src/commands/public/randomreact.js
@@ -11,10 +11,14 @@ module.exports = class extends Command {
   }
 
   async execute(message) {
-    const input = /(?:randomreact)\s+(.+)/.exec(message.content);
-    const msg = await message.channel.messages.fetch(input[1]).catch(e => null);
+    const match = /(?:randomreact)(?:\s+(?:<#)?(\d{17,20})>?)?(?:\s+(\d{17,20}))/.exec(message.content);
 
-    if (!msg) return message.reply("Unable to locate message ID specified.");
+    const msgChan = match[1] ? message.guild.channels.get(match[1]) : message.channel;
+    if (!msgChan) return message.reply("The provided channel ID is not valid.");
+
+    const msg = await msgChan.messages.fetch(match[2]).catch(e => null);
+
+    if (!msg) return message.reply("Unable to locate message ID.");
     if (!msg.reactions.size) return message.reply("Found message but unable to find reactions.");
 
     const winner = (await msg.reactions.random().users.fetch()).random();

--- a/src/commands/public/randomreact.js
+++ b/src/commands/public/randomreact.js
@@ -12,6 +12,7 @@ module.exports = class extends Command {
 
   async execute(message) {
     const match = /(?:randomreact)(?:\s+(?:<#)?(\d{17,20})>?)?(?:\s+(\d{17,20}))/.exec(message.content);
+    if (!match) return message.reply("Invalid Syntax: randomreact [channel-id/mention] <message-id/mention>");
 
     const msgChan = match[1] ? message.guild.channels.get(match[1]) : message.channel;
     if (!msgChan) return message.reply("The provided channel ID is not valid.");


### PR DESCRIPTION
Currently, the randomreact command can only be invoked from the channel that contains the specified message ID. This PR adds new syntax to allow a moderator to specify which channel they would like to search for the given message ID.