### PR TITLE
fix: 🐛 Change unmute variable check from typeof to instanceof

### DIFF
--- a/src/commands/public/unmute.js
+++ b/src/commands/public/unmute.js
@@ -49,7 +49,7 @@ module.exports = class extends Command {
       logsChan.send({ embed });
     }
 
-    if (typeof muteChan === TextChannel) muteChan.delete();
+    if (muteChan instanceof TextChannel) muteChan.delete();
     else if (muteChan && message.guild.channels.get(muteChan)) message.guild.channels.get(muteChan).delete();
 
     this.client.db.tempModActions.delete(`${message.guild.id}-${user.id}`);


### PR DESCRIPTION
Previously, the unmute command relied on a typeof check which would never evaluate to true. This PR changes the check to use instanceof which will allow for the command to work as intended