### PR TITLE
Implement additional logging for guild events

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -22,7 +22,7 @@ module.exports = {
     "change": "0x000000",
 
     // Message
-    "edit": "0xFF8800",
+    "edit": "0xFFFF00",
     "delete": "0xFF0000"
   },
   "defaultSettings": {

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -10,10 +10,20 @@ module.exports = {
     "blacklist": 0
   },
   "colours": {
+    // Status
     "info": "0x00FFF9",
     "error": "0xFF0000",
     "warn": "0xFF8800",
-    "success": "0x00FF00"
+    "success": "0x00FF00",
+
+    // Guild/VC
+    "join": "0x00FF00",
+    "leave": "0xFF0000",
+    "change": "0x000000",
+
+    // Message
+    "edit": "0xFF8800",
+    "delete": "0xFF0000"
   },
   "defaultSettings": {
     // AutoMod related settings

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -16,24 +16,27 @@ module.exports = {
     "success": "0x00FF00"
   },
   "defaultSettings": {
-    // Channel ID
-    "automodchannel": null,
-    // Array of strings
-    "automodlist": [],
-    // Category ID
-    "detentioncategory": null,
-    // Role ID
-    "detentionrole": null,
-    // Role ID
-    "helperrole": null,
-    // Channel ID
-    "modlogschannel": null,
-    // Role ID
-    "mutedrole": null,
-    // Role ID
-    "staffrole": null,
-    // Object
-    "starboard": {}
+    // AutoMod related settings
+    "automodchannel": null, // Channel ID
+    "automodlist": [], // Array of strings
+
+    // Detention/mute settings
+    "detentioncategory": null, // Category ID
+    "detentionrole": null, // Role ID
+
+    // Role/permission settings
+    "helperrole": null, // Role ID
+    "mutedrole": null, // Role ID
+    "staffrole": null, // Role ID
+
+    // Log channel settings
+    "modlogschannel": null, // Channel ID
+    "messagelogschannel": null, // Channel ID
+    "memberlogschannel": null, // Channel ID
+    "vclogschannel": null, // Channel ID
+
+    // Misc. settings
+    "starboard": {} // Object
   },
   "defaultNotes": {
     "actions": [],

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -27,7 +27,7 @@ module.exports = {
     // Role ID
     "helperrole": null,
     // Channel ID
-    "logschannel": null,
+    "modlogschannel": null,
     // Role ID
     "mutedrole": null,
     // Role ID

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   "defaultSettings": {
     // AutoMod related settings
-    "automodchannel": null, // Channel ID
+    "automodlogschannel": null, // Channel ID
     "automodlist": [], // Array of strings
 
     // Detention/mute settings

--- a/src/commands/dev/settingssync.js
+++ b/src/commands/dev/settingssync.js
@@ -16,15 +16,39 @@ module.exports = class extends Command {
    */
   async execute(message) {
     await this.client.db.settings.forEach(async (gSet, gID, map) => {
+
+      for (const gVal of Object.keys(gSet)) {
+        // If the default settings don't have a guild setting, delete it
+        if (!Object.keys(this.client.constants.defaultSettings).includes(gVal)) {
+          message.channel.send(`${gID} has an extra setting: ${gVal}. Deleting...`);
+          delete gSet[gVal];
+          continue;
+        }
+
+        // If the type of the default setting has changed, update the guild setting
+        if (
+          typeof gSet[gVal] !== typeof this.client.constants.defaultSettings[gVal] ||
+          (!gSet[gVal] && this.client.constants.defaultSettings[gVal]) ||
+          (gSet[gVal] && !this.client.constants.defaultSettings[gVal])
+        ) {
+          message.channel.send(`${gID} has a different type for setting ${gVal}. Updating...`);
+          gSet[gVal] = this.client.constants.defaultSettings[gVal];
+        }
+      }
+
       for (const defVal of Object.keys(this.client.constants.defaultSettings)) {
+        // If the guild settings are missing a default setting, add it
         if (!Object.prototype.hasOwnProperty.call(gSet, defVal)) {
           message.channel.send(`${gID} does not have setting ${defVal}. Setting...`);
           gSet[defVal] = this.client.constants.defaultSettings[defVal];
-          this.client.db.settings.set(gID, gSet);
         }
       }
+
+      // Sync changes to DB and send confirmation
+      this.client.db.settings.set(gID, gSet);
       await message.channel.send(`${gID} settings synced.`);
     });
+
     await message.channel.send("All guilds synced.");
   }
 };

--- a/src/commands/public/ban.js
+++ b/src/commands/public/ban.js
@@ -31,7 +31,7 @@ module.exports = class extends Command {
     await message.guild.members.ban(user.id);
 
     // Check if guild has logs channel
-    let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
+    let logsChan = this.client.db.settings.get(message.guild.id, "modlogschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
       logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, user, "Ban", match[2]) });

--- a/src/commands/public/detention.js
+++ b/src/commands/public/detention.js
@@ -60,7 +60,7 @@ module.exports = class extends Command {
       .catch(() => message.reply('Unable to DM user.'));
 
     // Check if guild has logs channel
-    let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
+    let logsChan = this.client.db.settings.get(message.guild.id, "modlogschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
       logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, detUser, "Detention", "N/A") });

--- a/src/commands/public/kick.js
+++ b/src/commands/public/kick.js
@@ -31,7 +31,7 @@ module.exports = class extends Command {
     await member.kick();
 
     // Check if guild has logs channel
-    let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
+    let logsChan = this.client.db.settings.get(message.guild.id, "modlogschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
       logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, user, "Kick", match[2]) });

--- a/src/commands/public/mute.js
+++ b/src/commands/public/mute.js
@@ -72,7 +72,7 @@ module.exports = class extends Command {
       .catch(() => message.reply('Unable to DM user.'));
 
     // Check if the guild has a logs channel
-    let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
+    let logsChan = this.client.db.settings.get(message.guild.id, "modlogschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
       logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, muteUser, `Mute (${muteLengthStr})`, match[6]) });

--- a/src/commands/public/settings.js
+++ b/src/commands/public/settings.js
@@ -44,7 +44,7 @@ module.exports = class extends Command {
       if (match[1] === "detentioncategory") return message.reply(this._setChannel(message, gSettings, match[1], match[2], true));
       if (match[1] === "detentionrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
       if (match[1] === "helperrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
-      if (match[1] === "logschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
+      if (match[1] === "modlogschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
       if (match[1] === "mutedrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
       if (match[1] === "staffrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
 

--- a/src/commands/public/settings.js
+++ b/src/commands/public/settings.js
@@ -40,7 +40,7 @@ module.exports = class extends Command {
       match[1] = match[1].toLowerCase();
 
       // Check if the provided setting matches existing settings and validate provided value before updating setting
-      if (match[1] === "automodchannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
+      if (match[1] === "automodlogschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
       if (match[1] === "detentioncategory") return message.reply(this._setChannel(message, gSettings, match[1], match[2], true));
       if (match[1] === "detentionrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
       if (match[1] === "helperrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));

--- a/src/commands/public/settings.js
+++ b/src/commands/public/settings.js
@@ -44,9 +44,12 @@ module.exports = class extends Command {
       if (match[1] === "detentioncategory") return message.reply(this._setChannel(message, gSettings, match[1], match[2], true));
       if (match[1] === "detentionrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
       if (match[1] === "helperrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
+      if (match[1] === "memberlogschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
+      if (match[1] === "messagelogschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
       if (match[1] === "modlogschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
       if (match[1] === "mutedrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
       if (match[1] === "staffrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
+      if (match[1] === "vclogschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
 
       return message.channel.reply(`Invalid seting provided: \`${match[1]}\`. ${this.possibleSettings}`);
     }

--- a/src/commands/public/silence.js
+++ b/src/commands/public/silence.js
@@ -39,7 +39,7 @@ module.exports = class extends Command {
       .catch(() => message.reply("Unable to DM user."));
 
     // Check if the guild has a logs channel
-    let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
+    let logsChan = this.client.db.settings.get(message.guild.id, "modlogschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
       logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, user, `Silence (${match[2]} minutes)`, match[3]) });

--- a/src/commands/public/tempban.js
+++ b/src/commands/public/tempban.js
@@ -34,7 +34,7 @@ module.exports = class extends Command {
     await member.ban();
 
     // Check if guild has logs channel
-    let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
+    let logsChan = this.client.db.settings.get(message.guild.id, "modlogschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
       logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, user, `Tempban (${match[2]} days)`, match[3]) });

--- a/src/commands/public/undetention.js
+++ b/src/commands/public/undetention.js
@@ -52,8 +52,8 @@ module.exports = class extends Command {
     const hastebinURL = await this.client.hastebin(muteChanMsg);
 
     // Check if the guild has a logs channel
-    if (gSettings["logschannel"] && message.guild.channels.get(gSettings["logschannel"])) {
-      const logsChan = message.guild.channels.get(gSettings["logschannel"]);
+    if (gSettings["modlogschannel"] && message.guild.channels.get(gSettings["modlogschannel"])) {
+      const logsChan = message.guild.channels.get(gSettings["modlogschannel"]);
 
       const embed = new MessageEmbed()
         .setAuthor(`${detUser.tag} (${detUser.id})`, detUser.displayAvatarURL())

--- a/src/commands/public/unmute.js
+++ b/src/commands/public/unmute.js
@@ -28,7 +28,7 @@ module.exports = class extends Command {
     // Fetch guild settings and mute channel
     const gSettings = this.client.db.settings.get(message.guild.id);
     let muteChan = this.client.db.detention.get(`${message.guild.id}-${user.id}`);
-    let logsChan = gSettings["logschannel"];
+    let logsChan = gSettings["modlogschannel"];
     let muteRole = gSettings["mutedrole"];
 
     // Check if mutedrole setting is still valid

--- a/src/commands/public/warn.js
+++ b/src/commands/public/warn.js
@@ -28,7 +28,7 @@ module.exports = class extends Command {
       .catch(() => message.reply("Unable to DM user."));
 
     // Check if there is a log channel and send the log information
-    let logsChan = this.client.db.settings.get(message.guild.id, "logschannel");
+    let logsChan = this.client.db.settings.get(message.guild.id, "modlogschannel");
     if (logsChan && message.guild.channels.get(logsChan)) {
       logsChan = message.guild.channels.get(logsChan);
       logsChan.send({ embed: this.client.constants.embedTemplates.logs(message, user, `Warn`, match[2]) });

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -1,0 +1,31 @@
+const Event = require("../structures/event.js");
+const moment = require("moment");
+const { MessageEmbed } = require("discord.js");
+
+module.exports = class extends Event {
+  constructor(client) {
+    super(client, {
+      name: "guildMemberAdd"
+    });
+  }
+
+  /**
+   * Entry point for guildMemberAdd event
+   * @param {GuildMember} ctx The member that joined the server
+   */
+  async execute(ctx = null) {
+    const guild = ctx.guild;
+    const gSettings = this.client.db.settings.get(guild.id);
+
+    if (gSettings["memberlogschannel"] && guild.channels.get(gSettings["memberlogschannel"])) {
+      const memberLogsChan = guild.channels.get(gSettings["memberlogschannel"]);
+      memberLogsChan.send({ 
+        embed: new MessageEmbed()
+          .setAuthor(`${ctx.user.tag} (${ctx.user.id})`, ctx.user.avatarURL())
+          .setColor(this.client.constants.colours.join)
+          .setDescription("User Joined")
+          .setTimestamp()
+      });
+    }
+  }
+};

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -15,13 +15,23 @@ module.exports = class extends Event {
    */
   async execute(ctx = null) {
     const guild = ctx.guild;
+    const gSettings = this.client.db.settings.get(guild.id);
+
+    if (gSettings["memberlogschannel"] && guild.channels.get(gSettings["memberlogschannel"])) {
+      const memberLogsChan = guild.channels.get(gSettings["memberlogschannel"]);
+      memberLogsChan.send({ 
+        embed: new MessageEmbed()
+          .setAuthor(`${ctx.user.tag} (${ctx.user.id})`, ctx.user.avatarURL())
+          .setColor(this.client.constants.colours.leave)
+          .setDescription("User Left/Banned")
+          .setTimestamp()
+      });
+    }
 
     // Attempt to fetch the user's detention channel and return if it doesn't exist
     let detChan = this.client.db.detention.get(`${guild.id}-${ctx.user.id}`);
     if (!detChan) return;
     detChan = guild.channels.get(detChan);
-
-    const gSettings = this.client.db.settings.get(guild.id);
 
     // Check if the guild has a logs channel
     if (gSettings["modlogschannel"] && guild.channels.get(gSettings["modlogschannel"])) {

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -24,8 +24,8 @@ module.exports = class extends Event {
     const gSettings = this.client.db.settings.get(guild.id);
 
     // Check if the guild has a logs channel
-    if (gSettings["logschannel"] && guild.channels.get(gSettings["logschannel"])) {
-      const logsChan = guild.channels.get(gSettings["logschannel"]);
+    if (gSettings["modlogschannel"] && guild.channels.get(gSettings["modlogschannel"])) {
+      const logsChan = guild.channels.get(gSettings["modlogschannel"]);
 
       // Fetch all messages from the detention channel and format them
       let detChanMsg = await this.client.getChanMsg(detChan);

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -122,8 +122,8 @@ module.exports = class extends Event {
           await message.delete();
 
           // Check if the guild has a channel to log automod violations in
-          if (gSettings["automodchannel"] && message.guild.channels.get(gSettings["automodchannel"])) {
-            const amChan = message.guild.channels.get(gSettings["automodchannel"]);
+          if (gSettings["automodlogschannel"] && message.guild.channels.get(gSettings["automodlogschannel"])) {
+            const amChan = message.guild.channels.get(gSettings["automodlogschannel"]);
 
             // Create automod violation embed
             const embed = new MessageEmbed()

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -1,0 +1,33 @@
+const Event = require('../structures/event.js');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class extends Event {
+  constructor(client) {
+    super(client, {
+      name: "messageDelete"
+    });
+  }
+
+  /**
+   * Entry point for messageDelete event
+   * @param {Message} message The deleted message
+   */
+  execute(message) {
+    if (!message.content) return;
+
+    const guild = message.guild;
+    const gSettings = this.client.db.settings.get(guild.id);
+
+    if (gSettings["messagelogschannel"] && guild.channels.get(gSettings["messagelogschannel"])) {
+      const messageLogsChan = guild.channels.get(gSettings["messagelogschannel"]);
+      messageLogsChan.send({
+        embed: new MessageEmbed()
+          .setAuthor(`${message.author.tag} (${message.author.id})`, message.author.avatarURL())
+          .setColor(this.client.constants.colours.delete)
+          .setDescription(message.content)
+          .setFooter("Message Deleted")
+          .setTimestamp()
+      });
+    }
+  }
+};

--- a/src/events/messageUpdate.js
+++ b/src/events/messageUpdate.js
@@ -1,0 +1,36 @@
+const Event = require('../structures/event.js');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class extends Event {
+  constructor(client) {
+    super(client, {
+      name: "messageUpdate"
+    });
+  }
+
+  /**
+   * Entry point for messageUpdateEvent
+   * 
+   * @param {Message} oldMsg The original version of the message
+   * @param {Message} newMsg The updated version of the message
+   */
+  execute(oldMsg, newMsg) {
+    if (oldMsg.content === newMsg.content) return;
+
+    const guild = oldMsg.guild;
+    const gSettings = this.client.db.settings.get(guild.id);
+
+    if (gSettings["messagelogschannel"] && guild.channels.get(gSettings["messagelogschannel"])) {
+      const messageLogsChan = guild.channels.get(gSettings["messagelogschannel"]);
+      messageLogsChan.send({
+        embed: new MessageEmbed()
+          .setAuthor(`${oldMsg.author.tag} (${oldMsg.author.id})`, oldMsg.author.avatarURL())
+          .setColor(this.client.constants.colours.edit)
+          .addField("Original Message", oldMsg.content, false)
+          .addField("Updated Message", newMsg.content, false)
+          .setFooter("Message Updated")
+          .setTimestamp()
+      });
+    }
+  }
+};

--- a/src/events/messageUpdate.js
+++ b/src/events/messageUpdate.js
@@ -9,7 +9,7 @@ module.exports = class extends Event {
   }
 
   /**
-   * Entry point for messageUpdateEvent
+   * Entry point for messageUpdate event
    * 
    * @param {Message} oldMsg The original version of the message
    * @param {Message} newMsg The updated version of the message

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -1,0 +1,63 @@
+const Event = require('../structures/event.js');
+const { MessageEmbed } = require('discord.js');
+
+module.exports = class extends Event {
+  constructor(client) {
+    super(client, {
+      name: "voiceStateUpdate"
+    });
+  }
+
+  /**
+   * Entry point for voiceStateUpdate event
+   * 
+   * @param {VoiceState} oldState Old instance of a member's VoiceState
+   * @param {VoiceState} newState New instance of a member's VoiceState
+   */
+  execute(oldState, newState) {
+    const oldID = oldState.channelID;
+    const newID = newState.channelID;
+
+    const guild = oldState.guild;
+    const gSettings = this.client.db.settings.get(guild.id);
+    if (!gSettings["vclogschannel"] || !guild.channels.get(gSettings["vclogschannel"])) return;
+    const vcLogsChan = guild.channels.get(gSettings["vclogschannel"]);
+
+    // VC Join
+    if (!oldID && newID) {
+      vcLogsChan.send({
+        embed: new MessageEmbed()
+          .setAuthor(`${newState.member.user.tag} (${newState.member.user.id})`, newState.member.user.avatarURL())
+          .setColor(this.client.constants.colours.join)
+          .setDescription(`${newState.channel.name} (${newState.channelID})`)
+          .setFooter("VC Joined")
+          .setTimestamp()
+      });
+    }
+
+    // VC Change
+    if (oldID && newID) {
+      vcLogsChan.send({
+        embed: new MessageEmbed()
+          .setAuthor(`${oldState.member.user.tag} (${oldState.member.user.id})`, oldState.member.user.avatarURL())
+          .setColor(this.client.constants.colours.change)
+          .addField("Old VC", `${oldState.channel.name} (${oldState.channelID})`)
+          .addField("New VC", `${newState.channel.name} (${newState.channelID})`)
+          .setFooter("VC Changed")
+          .setTimestamp()
+      });
+    }
+
+    // VC Leave
+    if (oldID && !newID) {
+      vcLogsChan.send({
+        embed: new MessageEmbed()
+          .setAuthor(`${oldState.member.user.tag} (${oldState.member.user.id})`, oldState.member.user.avatarURL())
+          .setColor(this.client.constants.colours.leave)
+          .setDescription(`${oldState.channel.name} (${oldState.channelID})`)
+          .setFooter("VC Left")
+          .setTimestamp()
+      });
+    }
+  }
+};

--- a/src/handlers/timers.js
+++ b/src/handlers/timers.js
@@ -63,9 +63,9 @@ class Timers {
           if (muteChan && (muteChan = guild.channels.get(muteChan))) {
 
             // Check if guild has a logs channel
-            if (gSettings["logschannel"] && guild.channels.get(gSettings["logschannel"])) {
+            if (gSettings["modlogschannel"] && guild.channels.get(gSettings["modlogschannel"])) {
 
-              const logsChan = guild.channels.get(gSettings["logschannel"]);
+              const logsChan = guild.channels.get(gSettings["modlogschannel"]);
 
               // Fetch all messages in channel
               let muteChanMsg = await this.client.getChanMsg(muteChan);


### PR DESCRIPTION
This PR adds additional logging features for messages, members, and voice channels. Staff members can use server settings to direct these logs into specific 

Logged events:
- Message Edit
- Message Delete
- Member Join
- Member Leave/Kick/Ban
- VC Join
- VC Change
- VC Leave

This PR closes issue #27.