### PR TITLE
fix: 🐛 Fixed emojistats dynamic spacing not working

### DIFF
--- a/src/commands/public/emojistats.js
+++ b/src/commands/public/emojistats.js
@@ -27,13 +27,13 @@ module.exports = class extends Command {
       if (!emoji) return;
       // Append the emoji name, dynamic spacer, and usage count to the message
       msg += `${emoji.name}`;
-      msg += `${" ".repeat(Math.max(...(emojiList)) - emoji.name.length + 1)}:: `;
+      msg += `${" ".repeat(Math.max(...(emojiList.map(el => el.length))) - emoji.name.length + 1)}:: `;
       msg += `${usageCount.toLocaleString()} usages\n`;
     });
 
     // Append all unused emoji
     for (const emoji of message.guild.emojis.values()) {
-      if (!sorted.has(emoji.id)) msg += `${emoji.name}${" ".repeat(Math.max(...(emojiList)) - emoji.name.length + 1)}:: 0 usages\n`;
+      if (!sorted.has(emoji.id)) msg += `${emoji.name}${" ".repeat(Math.max(...(emojiList.map(el => el.length))) - emoji.name.length + 1)}:: 0 usages\n`;
     }
 
     msg += `\`\`\``;


### PR DESCRIPTION
During recent refactors of the emojistats.js file, the map that grabs the lengths of the emoji names so that we can find the longest name and calculate a dynamic spacer based on that accidentally got removed and was returning NaN.

This fix re-adds that map so that dynamic spacers work again.

