### PR TITLE
Updated .gitignore; migrated mute to use snowflakes instead of usernames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ data
 
 # Testing files
 test.js
+
+# RethinkDB
+rethinkdb.exe
+rethinkdb_data/

--- a/src/commands/public/mute.js
+++ b/src/commands/public/mute.js
@@ -55,7 +55,7 @@ module.exports = class extends Command {
 
     // Create mute channel
     const muteChan = await message.guild.channels.create(
-      `mute-${muteUser.username.replace(/\s/, "-")}`,
+      `mute-${muteUser.id}`,
       {
         parent: detCat,
         reason: `${message.author.tag} muted ${muteUser.tag}`,

--- a/src/commands/public/unmute.js
+++ b/src/commands/public/unmute.js
@@ -76,5 +76,7 @@ module.exports = class extends Command {
 
     // Append unmute to user's mod notes DB entry
     this.client.handlers.modNotes.addAction(message, user, message.author, `Unmute`, match[2]);
+
+    return message.reply(`${user.tag} unmuted.`);
   }
 };


### PR DESCRIPTION
Updated .gitignore for RethinkDB.

Updated mute.js to use snowflakes in the channel name instead of usernames (same issue as #38).

Updated mute.js to return a unmuted message when a user is successfully unmuted.