### PR TITLE
feat: 🎸 Added anti Discord invite feature

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -26,6 +26,9 @@ module.exports = {
     "delete": "0xFF0000"
   },
   "defaultSettings": {
+    "antiinvite": null, // Boolean
+    "antiinvitewhitelist": null, // Array of strings
+
     // AutoMod related settings
     "automodlogschannel": null, // Channel ID
     "automodlist": [], // Array of strings

--- a/src/commands/public/antiinvite.js
+++ b/src/commands/public/antiinvite.js
@@ -1,0 +1,51 @@
+const Command = require("../../structures/command.js");
+
+module.exports = class extends Command {
+  constructor(client) {
+    super(client, {
+      name: "antiinvite",
+      aliases: ["ai"],
+      ltu: client.constants.perms.staff,
+      selfhost: true
+    });
+  }
+
+  /**
+   * Entry point for antiinvite command
+   * @param {Message} message The message that invoked the command
+   * @returns {Message} The response to the command
+   */
+  async execute(message) {
+    const addRegex = /(?:add)(?:\s+([\w\W]+))/.exec(message.content);
+    const removeRegex = /(?:remove)(?:\s+(\d+))/.exec(message.content);
+    const listRegex = /(?:list)/.exec(message.content);
+
+    // If no matching syntax is found, show help information
+    if (!addRegex && !removeRegex && !listRegex) {
+      let toReturn = "";
+      toReturn += "Invalid Command Usage\n";
+      toReturn += "```asciidoc\n";
+      toReturn += "= Command Syntax\n";
+      toReturn += `*:: ${this.client.config["discord"]["prefix"]}antiinvite <add|remove|list> [channel id|channel-number]\n`;
+      toReturn += "= Command Examples\n";
+      toReturn += `*:: ${this.client.config["discord"]["prefix"]}antiinvite add 553311497279897601\n`;
+      toReturn += `*:: ${this.client.config["discord"]["prefix"]}antiinvite remove 1\n`;
+      toReturn += `*:: ${this.client.config["discord"]["prefix"]}antiinvite list`;
+      toReturn += "```";
+
+      return message.channel.send(toReturn);
+    }
+
+    if (addRegex) {
+      return this.client.handlers.antiInvite.addChannel(message, addRegex[1])
+        .then(() => message.channel.send(`<#${addRegex[1]}> has been added to the whitelist`))
+        .catch(e => message.channel.send(`ERR: ${e}`));
+    } else if (removeRegex) {
+      return this.client.handlers.antiInvite.removeChannel(message, removeRegex[1])
+        .then(() => message.channel.send(`${removeRegex[1]} has been removed from the whitelist`))
+        .catch(e => message.channel.send(`ERR: ${e}`));
+    } else {
+      return message.channel.send(await this.client.handlers.antiInvite.listChannels(message));
+    }
+  }
+};

--- a/src/commands/public/settings.js
+++ b/src/commands/public/settings.js
@@ -38,8 +38,10 @@ module.exports = class extends Command {
     // If both a setting and value is provided
     if (match[1] && match[2]) {
       match[1] = match[1].toLowerCase();
+      match[2] = match[2].toLowerCase();
 
       // Check if the provided setting matches existing settings and validate provided value before updating setting
+      if (match[1] === "antiinvite") return message.reply(this._setBoolean(message, gSettings, match[1], match[2]));
       if (match[1] === "automodlogschannel") return message.reply(this._setChannel(message, gSettings, match[1], match[2], false));
       if (match[1] === "detentioncategory") return message.reply(this._setChannel(message, gSettings, match[1], match[2], true));
       if (match[1] === "detentionrole") return message.reply(this._setRole(message, gSettings, match[1], match[2]));
@@ -106,6 +108,27 @@ module.exports = class extends Command {
     this.client.handlers.db.update("settings", message.guild.id, gSettings);
 
     return `Setting \`${setting}\` set to \`${role.name}\``;
+  }
+
+  /**
+   * Stores boolean for a setting
+   * @private
+   * 
+   * @param {Message} message The message that invoked the command
+   * @param {object} gSettings The guild's settings
+   * @param {string} setting The setting to be changed
+   * @param {string} value The boolean to be stored
+   * 
+   * @returns {string} Output to be returned to user
+   */
+  _setBoolean(message, gSettings, setting, value) {
+    if (value != "true" && value != "false") return `The provided value is not a boolean: ${value}`;
+
+    // Update guild settings
+    gSettings[setting] = value;
+    this.client.handlers.db.update("settings", message.guild.id, gSettings);
+
+    return `Setting \`${setting}\` set to \`${value}\``;
   }
 
 };

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -14,6 +14,7 @@ module.exports = class extends Event {
    * @param {Message} ctx The message to be processed
    */
   async execute(ctx = null) {
+    const gSettings = await this.client.handlers.db.get("settings", ctx.guild.id);
 
     // Filter out other bots and DM channels
     if (ctx.author.bot) return;
@@ -23,12 +24,15 @@ module.exports = class extends Event {
     if (!await this.client.handlers.db.has("settings", ctx.guild.id)) {
       const defaultSettings = JSON.parse(JSON.stringify(this.client.constants.defaultSettings));
       defaultSettings["id"] = ctx.guild.id;
-      
+
       await this.client.handlers.db.insert("settings", defaultSettings);
     }
 
     // Check for automod violations
     await this.autoModCheck(ctx);
+
+    // Check for Discord invites
+    if (gSettings["antiinvite"] == "true") await this.antiInviteCheck(ctx);
 
     // [SH] Handle r/smashbros related data
     if (!this.client.config["selfhost"]) {
@@ -38,7 +42,7 @@ module.exports = class extends Event {
         ctx.guild.id === this.client.config["servSpec"]["modServ"] &&
         (ctx.channel.parent.id === this.client.config["servSpec"]["modCat"] || ctx.channel.parent.id === this.client.config["servSpec"]["voteCat"])
       ) {
-        if(!await this.client.handlers.db.has("activitystats", ctx.author.id))
+        if (!await this.client.handlers.db.has("activitystats", ctx.author.id))
           await this.client.handlers.db.insert("activitystats", {
             "id": ctx.author.id,
             "data": { "actions": 0, "messages": 1 }
@@ -110,8 +114,61 @@ module.exports = class extends Event {
    * 
    * @param {Message} message The message to be processed
    */
+  async antiInviteCheck(message) {
+    const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
+
+    // Allow the message to send if the sender was a staff member
+    if (gSettings["staffrole"] && message.member.roles.some(r => r.id === gSettings["staffrole"])) return;
+
+    // Check if guild has any channels in its whitelist
+    if (gSettings["antiinvitewhitelist"] && gSettings["antiinvitewhitelist"].length) {
+
+      // Loop over each whitelist entry
+      for (const term of gSettings["antiinvitewhitelist"]) {
+
+        // Construct and test regex to search for Discord invites
+        const checkRegex = new RegExp(`(https:\/\/)?(www\.)?(?:discord\.(?:gg|io|me|li)|discordapp\.com\/invite)\/([a-z0-9-.]+)?`, "i");
+        if (checkRegex.test(message.content)) {
+
+          // Fetch messages near the violation for context
+          let nearMsgs = await message.channel.messages.fetch({ limit: 5 });
+
+          // Reverse the order of the fetched messages to be oldest to newest
+          nearMsgs = new Collection([...nearMsgs].reverse());
+
+          await message.delete();
+
+          // Check if the guild has a channel to log automod violations in
+          if (gSettings["automodlogschannel"] && message.guild.channels.get(gSettings["automodlogschannel"])) {
+            const amChan = message.guild.channels.get(gSettings["automodlogschannel"]);
+
+            // Create automod violation embed
+            const embed = new MessageEmbed()
+              .setDescription(`**User sent a Discord invite in <#${message.channel.id}>**`)
+              .setColor(this.client.constants.colours.info)
+              .setTimestamp();
+
+            for (const m of nearMsgs.values()) {
+              embed.addField(`${m.author.tag} (${m.author.id})`, m.content.replace(term, `__**${term}**__`), false);
+            }
+
+            amChan.send({ embed });
+            return
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * 
+   * @param {Message} message The message to be processed
+   */
   async autoModCheck(message) {
     const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
+
+    // Allow the message to send if the sender was a staff member
+    if (gSettings["staffrole"] && message.member.roles.some(r => r.id === gSettings["staffrole"])) return;
 
     // Check if guild has anything in its automod list
     if (gSettings["automodlist"] && gSettings["automodlist"].length) {
@@ -122,9 +179,6 @@ module.exports = class extends Event {
         // Construct and test regex to search for banned term
         const checkRegex = new RegExp(`\\b${term}\\b`, "i");
         if (checkRegex.test(message.content)) {
-
-          // Allow the message to send if the sender was a staff member
-          if (gSettings["staffrole"] && message.member.roles.some(r => r.id === gSettings["staffrole"])) return;
 
           // Fetch messages near the violation for context
           let nearMsgs = await message.channel.messages.fetch({ limit: 5 });

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -125,35 +125,38 @@ module.exports = class extends Event {
 
       // Loop over each whitelist entry
       for (const channel of gSettings["antiinvitewhitelist"]) {
+        
+        if (message.channel.id != channel) {
 
-        // Construct and test regex to search for Discord invites
-        const checkRegex = new RegExp(`(https:\/\/)?(www\.)?(?:discord\.(?:gg|io|me|li)|discordapp\.com\/invite)\/([a-z0-9-.]+)?`, "i");
-        if (checkRegex.test(message.content)) {
+          // Construct and test regex to search for Discord invites
+          const checkRegex = new RegExp(`(https:\/\/)?(www\.)?(?:discord\.(?:gg|io|me|li)|discordapp\.com\/invite)\/([a-z0-9-.]+)?`, "i");
+          if (checkRegex.test(message.content)) {
 
-          // Fetch messages near the violation for context
-          let nearMsgs = await message.channel.messages.fetch({ limit: 5 });
+            // Fetch messages near the violation for context
+            let nearMsgs = await message.channel.messages.fetch({ limit: 5 });
 
-          // Reverse the order of the fetched messages to be oldest to newest
-          nearMsgs = new Collection([...nearMsgs].reverse());
+            // Reverse the order of the fetched messages to be oldest to newest
+            nearMsgs = new Collection([...nearMsgs].reverse());
 
-          await message.delete();
+            await message.delete();
 
-          // Check if the guild has a channel to log automod violations in
-          if (gSettings["automodlogschannel"] && message.guild.channels.get(gSettings["automodlogschannel"])) {
-            const amChan = message.guild.channels.get(gSettings["automodlogschannel"]);
+            // Check if the guild has a channel to log automod violations in
+            if (gSettings["automodlogschannel"] && message.guild.channels.get(gSettings["automodlogschannel"])) {
+              const amChan = message.guild.channels.get(gSettings["automodlogschannel"]);
 
-            // Create automod violation embed
-            const embed = new MessageEmbed()
-              .setDescription(`**User sent a Discord invite in <#${message.channel.id}>**`)
-              .setColor(this.client.constants.colours.info)
-              .setTimestamp();
+              // Create automod violation embed
+              const embed = new MessageEmbed()
+                .setDescription(`**User sent a Discord invite in <#${message.channel.id}>**`)
+                .setColor(this.client.constants.colours.info)
+                .setTimestamp();
 
-            for (const m of nearMsgs.values()) {
-              embed.addField(`${m.author.tag} (${m.author.id})`, m.content.replace(channel, `__**${channel}**__`), false);
+              for (const m of nearMsgs.values()) {
+                embed.addField(`${m.author.tag} (${m.author.id})`, m.content.replace(channel, `__**${channel}**__`), false);
+              }
+
+              amChan.send({ embed });
+              return
             }
-
-            amChan.send({ embed });
-            return
           }
         }
       }

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -124,7 +124,7 @@ module.exports = class extends Event {
     if (gSettings["antiinvitewhitelist"] && gSettings["antiinvitewhitelist"].length) {
 
       // Loop over each whitelist entry
-      for (const term of gSettings["antiinvitewhitelist"]) {
+      for (const channel of gSettings["antiinvitewhitelist"]) {
 
         // Construct and test regex to search for Discord invites
         const checkRegex = new RegExp(`(https:\/\/)?(www\.)?(?:discord\.(?:gg|io|me|li)|discordapp\.com\/invite)\/([a-z0-9-.]+)?`, "i");
@@ -149,7 +149,7 @@ module.exports = class extends Event {
               .setTimestamp();
 
             for (const m of nearMsgs.values()) {
-              embed.addField(`${m.author.tag} (${m.author.id})`, m.content.replace(term, `__**${term}**__`), false);
+              embed.addField(`${m.author.tag} (${m.author.id})`, m.content.replace(channel, `__**${channel}**__`), false);
             }
 
             amChan.send({ embed });

--- a/src/handlers/antiInvite.js
+++ b/src/handlers/antiInvite.js
@@ -13,7 +13,7 @@ class AntiInvite {
     return new Promise(async (resolve, reject) => {
       const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
 
-      if (gSettings["antiinvitewhitelist"].indexOf(channel) !== -1) return reject(`\`${channel} is already on this server's anti invite whitelist\``);
+      if (gSettings["antiinvitewhitelist"].indexOf(channel) !== -1) return reject(`\`${channel} is already on this server's anti-invite whitelist\``);
       gSettings["antiinvitewhitelist"].push(channel);
 
       await this.client.handlers.db.update("settings", message.guild.id, gSettings);

--- a/src/handlers/antiInvite.js
+++ b/src/handlers/antiInvite.js
@@ -38,7 +38,8 @@ class AntiInvite {
         // Loop over each channel
         gSettings["antiinvitewhitelist"].forEach((val, index) => {
           // Append channel to string in a formatted form
-          toSend += `${index + 1}. ${val}${gSettings["antiinvitewhitelist"].length > index ? ` (#${(message.guild.channels.get(val).name)})\n` : ""}`;
+          toSend += `${index + 1}. ${val}${gSettings["antiinvitewhitelist"].length > index ? `\n` : ""}`;
+          // toSend += `${index + 1}. ${val}${gSettings["automodlist"].length > index ? "\n" : ""}`;
         });
       }
 
@@ -59,9 +60,9 @@ class AntiInvite {
 
     return new Promise(async (resolve, reject) => {
       const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
-
+      console.log(gSettings)
       if (!gSettings["antiinvitewhitelist"].length) return reject("Anti-invite channel list is empty.");
-      if (!gSettings["antiinvitewhitelist"][number]) return reject(`No entry was found for channel ${number + 1}`);
+      if (!gSettings["antiinvitewhitelist"][number]) return reject(`No entry was found for channel ${channel}`);
 
       // Remove channel from whitelist
       gSettings["antiinvitewhitelist"].splice(number, 1);

--- a/src/handlers/antiInvite.js
+++ b/src/handlers/antiInvite.js
@@ -1,0 +1,75 @@
+class AntiInvite {
+  constructor(client) {
+    this.client = client;
+  }
+
+  /**
+   * Adds a channel to a guild's anti-invite whitelist
+   * @param {Message} message The original message from the command
+   * @param {string} channel The channel to be whitelisted
+   * @returns {Promise<string>|Promise<>} An empty resolved promise or a rejected promise with an error
+   */
+  addChannel(message, channel) {
+    return new Promise(async (resolve, reject) => {
+      const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
+
+      if (gSettings["antiinvitewhitelist"].indexOf(channel) !== -1) return reject(`\`${channel} is already on this server's anti invite whitelist\``);
+      gSettings["antiinvitewhitelist"].push(channel);
+
+      await this.client.handlers.db.update("settings", message.guild.id, gSettings);
+
+      return resolve();
+    });
+  }
+
+  /**
+   * Fetch a guild's anti-invite whitelist and return a formatted version
+   * @param {Message} message The original message from the command
+   * @returns {Promise<string>} A promise with the guild's anti-invite whitelist
+   */
+  listChannels(message) {
+    return new Promise(async (resolve, reject) => {
+      const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
+      let toSend = `__**Anti-invite whitelist for ${message.guild.name}**__\`\`\`md\n`;
+
+      // Check if guild has whitelisted any channels
+      if (!gSettings["antiinvitewhitelist"].length) return resolve(`${message.guild.name}'s anti-invite whitelist is empty.`);
+      else {
+        // Loop over each channel
+        gSettings["antiinvitewhitelist"].forEach((val, index) => {
+          // Append channel to string in a formatted form
+          toSend += `${index + 1}. ${val}${gSettings["antiinvitewhitelist"].length > index ? ` (#${(message.guild.channels.get(val).name)})\n` : ""}`;
+        });
+      }
+
+      toSend += "```";
+      return resolve(toSend);
+    });
+  }
+
+  /**
+   * Removes a channel from a guild's anti-invite whitelist
+   * @param {Message} message The original message from the command
+   * @param {string} number The number of the channel to be removed
+   * @returns {Promise<string>|Promise<>} An empty resolved promise or a rejected promise with an error
+   */
+  removeChannel(message, number) {
+    // Arrays start at zero
+    number = Number(number) - 1;
+
+    return new Promise(async (resolve, reject) => {
+      const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
+
+      if (!gSettings["antiinvitewhitelist"].length) return reject("Anti-invite channel list is empty.");
+      if (!gSettings["antiinvitewhitelist"][number]) return reject(`No entry was found for channel ${number + 1}`);
+
+      // Remove channel from whitelist
+      gSettings["antiinvitewhitelist"].splice(number, 1);
+
+      await this.client.handlers.db.update("settings", message.guild.id, gSettings);
+      return resolve();
+    });
+  }
+}
+
+module.exports = AntiInvite;

--- a/src/handlers/antiInvite.js
+++ b/src/handlers/antiInvite.js
@@ -60,7 +60,6 @@ class AntiInvite {
 
     return new Promise(async (resolve, reject) => {
       const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
-      console.log(gSettings)
       if (!gSettings["antiinvitewhitelist"].length) return reject("Anti-invite channel list is empty.");
       if (!gSettings["antiinvitewhitelist"][number]) return reject(`No entry was found for channel ${channel}`);
 

--- a/src/handlers/autoMod.js
+++ b/src/handlers/autoMod.js
@@ -59,7 +59,6 @@ class AutoMod {
    * @returns {Promise<string>|Promise<>} An empty resolved promise or a rejected promise with an error
    */
   removeWord(message, number) {
-
     // Arrays start at zero
     number = Number(number) - 1;
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,9 @@ new class extends Client {
 
     // Load Global Handlers
     this.handlers = {};
+    this.handlers.autoInvite = new (require("./handlers/antiInvite.js"))(this);
     this.handlers.autoMod = new (require("./handlers/autoMod.js"))(this);
-    this.handlers.db = new(require("./handlers/database.js"))(this);
+    this.handlers.db = new (require("./handlers/database.js"))(this);
     this.handlers.modNotes = new (require("./handlers/modNotes.js"))(this);
     this.handlers.starboard = new (require("./handlers/starboard.js"))(this);
     this.handlers.timers = new (require("./handlers/timers.js"))(this);

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ new class extends Client {
 
     // Load Global Handlers
     this.handlers = {};
-    this.handlers.autoInvite = new (require("./handlers/antiInvite.js"))(this);
+    this.handlers.antiInvite = new (require("./handlers/antiInvite.js"))(this);
     this.handlers.autoMod = new (require("./handlers/autoMod.js"))(this);
     this.handlers.db = new (require("./handlers/database.js"))(this);
     this.handlers.modNotes = new (require("./handlers/modNotes.js"))(this);


### PR DESCRIPTION
This PR implements an anti Discord invite feature which will automatically remove Discord invites sent by users without the staff role outside of channels on the whitelist. The syntax is relatively similar to the AutoMod syntax. 

Commands:
```=settings antiinvite true/false```
```=antiinvite add 553311497279897601```
```=antiinvite list```
```=antiinvite remove 1```

RethinkDB insert queries:
```r.db("setsudo").table("settings").update({"antiinvite": "false"})```
```r.db("setsudo").table("settings").update({"antiinvitewhitelist": []})```

