### PR TITLE
Implement purge command and purge ban argument

### DIFF
--- a/src/commands/public/ban.js
+++ b/src/commands/public/ban.js
@@ -16,30 +16,30 @@ module.exports = class extends Command {
    */
   async execute(message) {
     // addAction(message, user, mod, action, reason)
-    const match = /(?:ban)\s+(?:(?:<@!?)?(\d{17,20})>?)(?:\s+([\w\W]+))/.exec(message.content);
-    if (!match) return message.reply("Invalid Syntax: ban <user-id/mention> <msg>");
+    const match = /(?:ban)\s+(?:(?:<@!?)?(\d{17,20})>?)(?:\s+([0-7]))?(?:\s+([\w\W]+))/.exec(message.content);
+    if (!match) return message.reply("Invalid Syntax: ban <user-id/mention> [days-to-purge] <msg>");
 
     // Fetch affected user
     const user = await this.client.users.fetch(match[1]);
 
     // DM affected user that they were banned along with the ban appeal URL if possible
-    await user.send({ embed: this.client.constants.embedTemplates.dm(message, "Banned", match[2]) })
+    await user.send({ embed: this.client.constants.embedTemplates.dm(message, "Banned", match[3]) })
       .catch(() => message.reply("Unable to DM user."));
     await user.send(`You may appeal at the URL below.\n<${this.client.constants.banAppealURL}>`)
       .catch(() => null);
 
-    await message.guild.members.ban(user.id);
+    await message.guild.members.ban(user.id, { days: match[2] || 0 });
 
     // Check if guild has logs channel
     const gSettings = await this.client.handlers.db.get("settings", message.guild.id);
     if (gSettings["modlogschannel"] && message.guild.channels.get(gSettings["modlogschannel"])) {
       message.guild.channels
         .get(gSettings["modlogschannel"])
-        .send({ embed: this.client.constants.embedTemplates.logs(message, user, "Ban", match[2]) });
+        .send({ embed: this.client.constants.embedTemplates.logs(message, user, "Ban", match[3]) });
     }
 
     // Append ban to user's mod notes DB entry
-    this.client.handlers.modNotes.addAction(message, user, message.author, "Ban", match[2]);
+    this.client.handlers.modNotes.addAction(message, user, message.author, "Ban", match[3]);
     
     return message.reply(`${user.tag} banned.`);
   }

--- a/src/commands/public/purge.js
+++ b/src/commands/public/purge.js
@@ -1,0 +1,34 @@
+const Command = require("../../structures/command.js");
+
+module.exports = class extends Command {
+  constructor(client) {
+    super(client, {
+      name: "purge",
+      aliases: ["prune", "clean"],
+      ltu: client.constants.perms.staff,
+      selfhost: true
+    });
+  }
+
+  /**
+   * Entry point for purge command
+   * @param {Message} message The message that invoked the command
+   */
+  async execute(message) {
+    const match = /(?:purge)(?:\s+(?:<@!?)?(\d{17,20})>?)?(?:\s+(\d{0,2}))/.exec(message.content);
+    if (!match) return message.reply("Invalid Syntax: purge [user-id/mention>] <msg-count>");
+
+    let chanMsg;
+    if (match[1]) {
+      chanMsg = await message.channel.messages.fetch({ limit: 100 });
+      if (!chanMsg || !chanMsg.size) return message.reply("An error occurred! I couldn't find any messages to purge.");
+
+      chanMsg = chanMsg.filter(msg => msg.author.id === match[1]);
+      if (!chanMsg.size) return message.reply("An error occurred! I couldn't find any messages from the provided user to purge.");
+    }
+
+    return message.channel.bulkDelete(match[1] ? chanMsg : match[2])
+      .then(() => message.reply(`${match[2]} messages deleted!`).then(m => m.delete({ timeout: 5000 })))
+      .catch(() => message.reply("An error occurred! I cannot purge messages over two weeks old."));
+  }
+};


### PR DESCRIPTION
As of right now, moderators do not have a way to purge messages. If the mods wish to purge a user's messages when banning, they have to use a right-click ban instead of using the bot.

This PR adds a new purge command with an optional user argument to clean up channels. In addition, a "days to purge" argument has been added to the ban command to remove the reliance on right-click banning.

Closes #34 