### PR TITLE
Added filtered command that DMs users filtered words

### DIFF
--- a/src/commands/smashbros/filtered.js
+++ b/src/commands/smashbros/filtered.js
@@ -1,0 +1,21 @@
+const Command = require("../../structures/command.js");
+
+module.exports = class extends Command {
+  constructor(client) {
+    super(client, {
+      name: "filtered",
+      aliases: [],
+      ltu: client.constants.perms.user,
+      selfhost: false
+    });
+  }
+
+  /**
+   * Entry point for filtered command
+   * @param {Message} message The message that invoked the command
+   * @returns {Message} The response to the command
+   */
+  async execute(message) {
+      return message.author.send(await this.client.handlers.autoMod.listWords(message));
+  }
+};

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -14,11 +14,11 @@ module.exports = class extends Event {
    * @param {Message} ctx The message to be processed
    */
   async execute(ctx = null) {
-    const gSettings = await this.client.handlers.db.get("settings", ctx.guild.id);
-
     // Filter out other bots and DM channels
     if (ctx.author.bot) return;
     if (ctx.channel.type !== "text") return;
+
+    const gSettings = await this.client.handlers.db.get("settings", ctx.guild.id);
 
     // Create guild settings if they don't exist
     if (!await this.client.handlers.db.has("settings", ctx.guild.id)) {


### PR DESCRIPTION
This PR adds the `=filtered` user command that allows users to request for Setsudo to DM them a list of the words currently in the AutoMod list (`=am list`).

The syntax for the new command is:
`=filtered`

The `message.js` database line had to be moved down below the bot/DM check so that it doesn't try to grab a non-existent ID.